### PR TITLE
providing fix for https://github.com/krakenjs/makara/issues/76

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### pulvus-provide unreleased
+
+* fix for https://github.com/krakenjs/makara/issues/76
+
 ### pulvus-provide v1.0.1
 
 * fix syntax error

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "rragan",
     "url": "https://github.com/rragan"
   },
-  "contributors" : ["Matt Edelman <medelman@paypal.com>"],
+  "contributors" : ["Matt Edelman <medelman@paypal.com>", "Cédric Connes <cedric.connes@gmail.com>"],
   "repository": {
     "type": "git",
     "url": "git://github.com/krakenjs/festucam.git"
@@ -25,7 +25,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "dustjs-linkedin": "~2.0.0",
+    "dustjs-linkedin": "~2.6.0",
     "dustjs-helpers": "~1.1.1",
     "chai": "~1.5.0",
     "grunt": "~0.4.1",

--- a/src/helpers/data/provide/provide.js
+++ b/src/helpers/data/provide/provide.js
@@ -7,36 +7,66 @@
     factory(root.dust);
   }
 }(this, function (dust) {
-  dust.helpers.provide = function provide(chunk, ctx, bodies, params) {
-    'use strict';
-    var resData,
-      blockData,
-      paramVals = {},
-      k,
-      localCtx = ctx,
-      saveData = chunk.data;
-
+  //from https://github.com/unitag/dust-provide-helper
+  dust.helpers.provide = function provideHelper(chunk, context, bodies, params) {
+    // Apply params to the local context if needed
+    var localContext = context;
     if (params) {
-      localCtx = ctx.push(params); // make params available to all bodies
+      localContext = context.push(params);
     }
 
-    for (k in bodies) {
-      if (k !== 'block') {
-        chunk.data = [];
-        try {
-          blockData = bodies[k](chunk, localCtx).data.join('');
-          resData = JSON.parse(blockData);
-        } catch (e) {
-          resData = blockData; // not valid JSON so just return raw data
+    // Create a new chunk (blank workspace)
+    return chunk.map(function render(branch) {
+      // Save the initial neighbor (allows to extract rendered variables)
+      var next = branch.next;
+
+      // Make the initial chunk unflushable, so that the rendered variables
+      // can be intercepted
+      chunk.flushable = false;
+
+      // Render all variable bodies, and store the resulting values
+      var values = {};
+      for (var key in bodies) {
+        if (key !== 'block') {
+          var data = getData(bodies[key]);
+          try {
+            values[key] = JSON.parse(data);
+          } catch (error) {
+            values[key] = data;
+          }
         }
-        paramVals[k] = resData;
       }
-    }
-    chunk.data = saveData;
 
-    // combine block-defined params with any existing ones.
-    // Block param overrides if name duplicates regular 11Guparam
-    return bodies.block(chunk, localCtx.push(paramVals));
+      // Make the initial chunk flushable again, so that the main body can
+      // be rendered correctly
+      chunk.flushable = true;
 
-  };
+      // Render the main body, with rendered variables injected into its
+      // local context
+      branch.render(bodies.block, localContext.push(values)).end();
+
+      // Render the given body, but return the generated content instead of
+      // writing it to the output
+      function getData(body) {
+        // Render the given body
+        branch.render(body, localContext);
+
+        // Walk through the generated content, and gather output data
+        var chunk = branch;
+        var data = [];
+
+        while (chunk !== next) {
+          data.push.apply(data, chunk.data);
+          chunk = chunk.next;
+        }
+
+        // Remove the generated content from the output
+        branch.data = [];
+        branch.next = next;
+
+        // Return the extracted data
+        return data.join('');
+      }
+    });
+  }
 }));

--- a/test/helpers/message.js
+++ b/test/helpers/message.js
@@ -1,0 +1,18 @@
+(function(root, factory) {
+	if (typeof define === 'function' && define.amd && define.amd.dust === true) {
+		define(['dust.core'], factory);
+	} else if (typeof exports === 'object') {
+		module.exports = factory(require('dustjs-linkedin'));
+	} else {
+		factory(root.dust);
+	}
+}(this, function (dust) {
+	dust.helpers.message = function messageHelper(chunk, context, bodies, params) {
+		//simulates https://github.com/krakenjs/dust-message-helper/blob/master/index.js (paired mode)
+		chunk.write(JSON.stringify(params.obi));
+		//return chunk;
+		return chunk.map(function (chunk) {
+			chunk.render(bodies.block, context).end();
+		});
+	}
+}));

--- a/test/provide-test.js
+++ b/test/provide-test.js
@@ -93,4 +93,12 @@ describe('provide', function () {
       assert.equal(out, '6');
     });
   });
+  it('param can be complex object', function () {
+    //simulates https://github.com/krakenjs/dust-message-helper mode=paired use case
+
+    var code = '{@provide}{#param}{$id}{/param}{:param}[{"$id":"foo","$elt":"bar"},{"$id":"bing","$elt":"bang"},{"$id":"baz","$elt":"biff"}]{/provide}';
+    dust.renderSource(code, context, function (err, out) {
+      assert.equal(out, 'foobingbaz');
+    });
+  });
 });

--- a/test/provide-test.js
+++ b/test/provide-test.js
@@ -1,6 +1,8 @@
 /*global dust: true */
-dust = require('dustjs-linkedin');
+var dust = require('dustjs-linkedin');
+dust.debugLevel = 'DEBUG';
 require('dustjs-helpers');
+require('./helpers/message');
 require('../src/helpers/data/provide/provide');
 var assert = require('assert');
 
@@ -95,8 +97,10 @@ describe('provide', function () {
   });
   it('param can be complex object', function () {
     //simulates https://github.com/krakenjs/dust-message-helper mode=paired use case
-
-    var code = '{@provide}{#param}{$id}{/param}{:param}[{"$id":"foo","$elt":"bar"},{"$id":"bing","$elt":"bang"},{"$id":"baz","$elt":"biff"}]{/provide}';
+    var context = {
+      obj: [{"$id":"foo","$elt":"bar"},{"$id":"bing","$elt":"bang"},{"$id":"baz","$elt":"biff"}]
+    };
+    var code = '{@provide}{#param}{$id}{/param}{:param}{@message obi=obj/}{/provide}';
     dust.renderSource(code, context, function (err, out) {
       assert.equal(out, 'foobingbaz');
     });


### PR DESCRIPTION
allows `@provide` to work with makara2 `dust-message-helper` in "paired" mode.

See: https://github.com/krakenjs/makara/blob/v2.x/ADVANCED.md
Resolves: https://github.com/krakenjs/makara/issues/76
