### PR TITLE
[tech] add support to use the existing dust context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-festucam
-==========
+# festucam
 
-Repository for contributed helper and filter extensions to dust
+Repository for contributed helper and filter extensions to dust.
 
 Forked from Rich Ragan's [dust-motes](https://github.com/rragan/dust-motes).
+
+## Helpers document references
+
+|Category|Helper|
+|:---|:---|
+|Data|[pulvus-provide](master/src/helpers/data/provide)|
+|HTML|[dustmotes-layout](master/src/helpers/html/layout)|
+|Strings|[substr](master/src/helpers/strings/substr)|
+|Miscellaneous|[extend](master/src/helpers/miscellaneous/extend)|

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "festucam",
   "description": "Collection of dust helpers/filters.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/krakenjs/festucam",
   "author": {
     "name": "rragan",
     "url": "https://github.com/rragan"
   },
-  "contributors" : ["Matt Edelman <medelman@paypal.com>", "Cédric Connes <cedric.connes@gmail.com>"],
+  "contributors": [
+    "Matt Edelman <medelman@paypal.com>",
+    "Cédric Connes <cedric.connes@gmail.com>"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/krakenjs/festucam.git"
@@ -22,8 +25,7 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "dustjs-linkedin": "~2.6.0",
     "dustjs-helpers": "~1.1.1",

--- a/src/helpers/data/provide/provide.js
+++ b/src/helpers/data/provide/provide.js
@@ -1,8 +1,11 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd && define.amd.dust === true) {
     define(['dust.core'], factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory(require('dustjs-linkedin'));
+  } else if (typeof module === 'object') {
+    module.exports = {
+      provide: factory(require('dustjs-linkedin')),
+      registerWith: factory
+    };
   } else {
     factory(root.dust);
   }

--- a/src/helpers/data/provide/provide.js
+++ b/src/helpers/data/provide/provide.js
@@ -2,10 +2,8 @@
   if (typeof define === 'function' && define.amd && define.amd.dust === true) {
     define(['dust.core'], factory);
   } else if (typeof module === 'object') {
-    module.exports = {
-      provide: factory(require('dustjs-linkedin')),
-      registerWith: factory
-    };
+    module.exports = factory(require('dustjs-linkedin'));
+    module.exports.registerWith = factory;
   } else {
     factory(root.dust);
   }
@@ -72,4 +70,6 @@
       }
     });
   }
+
+  return dust;
 }));


### PR DESCRIPTION
## Changes

- [x] Add support to use the existing dust context for Node v8 or above.

- [x] All test are working locally, no change in test cases.

- [x] Change package version from `0.0.1` to `0.0.2`.

References:
https://github.com/linkedin/dustjs-helpers/pull/146


